### PR TITLE
feat: Add --no-play-store flag for offline analysis

### DIFF
--- a/cmd/apkingo/main.go
+++ b/cmd/apkingo/main.go
@@ -41,7 +41,7 @@ func main() {
 	// Regular APK processing
 	app := analyzer.AndroidApp{}
 
-	if err := app.ProcessAPK(cfg.APKPath, cfg.Country, cfg.VTAPIKey, cfg.KAPIKey); err != nil {
+	if err := app.ProcessAPK(cfg.APKPath, cfg.Country, cfg.VTAPIKey, cfg.KAPIKey, cfg.NoPlayStore); err != nil {
 		log.Fatalf("Error processing APK: %v", err)
 	}
 
@@ -81,7 +81,7 @@ func processXAPK(cfg *config.Config, printer *ui.Printer, reporter *report.Repor
 
 		app := analyzer.AndroidApp{}
 
-		if err := app.ProcessAPK(apkPath, cfg.Country, cfg.VTAPIKey, cfg.KAPIKey); err != nil {
+		if err := app.ProcessAPK(apkPath, cfg.Country, cfg.VTAPIKey, cfg.KAPIKey, cfg.NoPlayStore); err != nil {
 			fmt.Printf("  [!] Failed to process: %v\n", err)
 			failed = append(failed, apkPath)
 			continue
@@ -120,7 +120,7 @@ func processXAPK(cfg *config.Config, printer *ui.Printer, reporter *report.Repor
 func processDirectory(cfg *config.Config, printer *ui.Printer, reporter *report.Reporter) {
 	fmt.Printf("[i] Analyzing APKs in directory: %s\n", cfg.DirPath)
 
-	results, failed, err := analyzer.AnalyzeDirectory(cfg.DirPath, cfg.Country, cfg.VTAPIKey, cfg.KAPIKey)
+	results, failed, err := analyzer.AnalyzeDirectory(cfg.DirPath, cfg.Country, cfg.VTAPIKey, cfg.KAPIKey, cfg.NoPlayStore)
 	if err != nil {
 		log.Fatalf("Error analyzing directory: %v", err)
 	}

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -13,19 +13,20 @@ import (
 
 // AndroidApp represents information extracted from an APK file
 type AndroidApp struct {
-	Name         string               `json:"name"`
-	PackageName  string               `json:"package-name"`
+	Name          string               `json:"name"`
+	PackageName   string               `json:"package-name"`
 	Version      string               `json:"version"`
 	MainActivity string               `json:"main-activity"`
 	MinimumSDK   int32                `json:"minimum-sdk"`
 	TargetSDK    int32                `json:"target-sdk"`
-	Hashes       Hashes               `json:"hashes"`
+	Hashes       Hashes              `json:"hashes"`
 	Permissions  []string             `json:"permissions"`
-	Metadata     []Metadata           `json:"metadata"`
-	Certificate  CertificateInfo      `json:"certificate"`
-	PlayStore    *PlayStoreInfo       `json:"playstore,omitempty"`
+	Metadata     []Metadata          `json:"metadata"`
+	Certificate  CertificateInfo     `json:"certificate"`
+	PlayStore    *PlayStoreInfo      `json:"playstore,omitempty"`
 	Koodous      *koodous.KoodousInfo `json:"koodous,omitempty"`
 	VirusTotal   *vt.VirusTotalInfo   `json:"virustotal,omitempty"`
+	NoPlayStore  bool                `json:"-"` // internal use only - skip Play Store
 	Errors       AnalysisErrors       `json:"-"` // internal use only
 }
 
@@ -52,7 +53,8 @@ type Metadata struct {
 }
 
 // ProcessAPK orchestrates the APK analysis
-func (app *AndroidApp) ProcessAPK(apkPath, country, vtAPIKey, koodousAPI string) error {
+// noPlayStore when true, skips Play Store API calls for offline analysis
+func (app *AndroidApp) ProcessAPK(apkPath, country, vtAPIKey, koodousAPI string, noPlayStore bool) error {
 	pkg, err := apk.OpenFile(apkPath)
 	if err != nil {
 		return fmt.Errorf("error loading APK: %s", err)
@@ -75,18 +77,23 @@ func (app *AndroidApp) ProcessAPK(apkPath, country, vtAPIKey, koodousAPI string)
 		app.Errors.Cert = err
 	}
 
+	// Track if user requested no Play Store
+	app.NoPlayStore = noPlayStore
+
 	// Run external API calls concurrently for better performance
 	var wg sync.WaitGroup
 
-	// PlayStore
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		if err := app.SetPlayStoreInfo(country); err != nil {
-			app.Errors.PlayStore = err
-			// Error is stored for reporting and will be displayed in output
-		}
-	}()
+	// PlayStore - skip if noPlayStore flag is set
+	if !noPlayStore {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := app.SetPlayStoreInfo(country); err != nil {
+				app.Errors.PlayStore = err
+				// Error is stored for reporting and will be displayed in output
+			}
+		}()
+	}
 
 	// Koodous
 	if koodousAPI != "" {

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -13,7 +13,7 @@ func TestProcessAPK(t *testing.T) {
 	app := analyzer.AndroidApp{}
 
 	// Test with no API keys
-	err := app.ProcessAPK(apkPath, "us", "", "")
+	err := app.ProcessAPK(apkPath, "us", "", "", false)
 	if err != nil {
 		t.Fatalf("ProcessAPK failed: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestProcessAPK(t *testing.T) {
 
 func TestProcessAPK_FileNotFound(t *testing.T) {
 	app := analyzer.AndroidApp{}
-	err := app.ProcessAPK("nonexistent.apk", "us", "", "")
+	err := app.ProcessAPK("nonexistent.apk", "us", "", "", false)
 	if err == nil {
 		t.Error("Expected error for non-existent file, got nil")
 	}

--- a/internal/analyzer/batch.go
+++ b/internal/analyzer/batch.go
@@ -9,8 +9,9 @@ import (
 
 // AnalyzeDirectory analyzes all APK files in a given directory.
 // It takes country and API keys for external service lookups (VirusTotal, Koodous).
+// noPlayStore when true, skips Play Store API calls for offline analysis.
 // Returns a map of file paths to AndroidApp results and a slice of failed paths.
-func AnalyzeDirectory(dirPath, country, vtAPIKey, koodousAPI string) (map[string]*AndroidApp, []string, error) {
+func AnalyzeDirectory(dirPath, country, vtAPIKey, koodousAPI string, noPlayStore bool) (map[string]*AndroidApp, []string, error) {
 	// Check if directory exists
 	info, err := os.Stat(dirPath)
 	if err != nil {
@@ -41,7 +42,7 @@ func AnalyzeDirectory(dirPath, country, vtAPIKey, koodousAPI string) (map[string
 		fmt.Printf("[%d/%d] Processing: %s\n", i+1, len(apkPaths), filepath.Base(apkPath))
 
 		app := &AndroidApp{}
-		if err := app.ProcessAPK(apkPath, country, vtAPIKey, koodousAPI); err != nil {
+		if err := app.ProcessAPK(apkPath, country, vtAPIKey, koodousAPI, noPlayStore); err != nil {
 			// Log error but continue with other files
 			fmt.Printf("  [!] Failed to process: %v\n", err)
 			failed = append(failed, apkPath)

--- a/internal/analyzer/batch_test.go
+++ b/internal/analyzer/batch_test.go
@@ -55,7 +55,7 @@ func TestAnalyzeDirectory_EmptyDir(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	_, _, err = AnalyzeDirectory(tmpDir, "us", "", "")
+	_, _, err = AnalyzeDirectory(tmpDir, "us", "", "", false)
 	if err == nil {
 		t.Error("Expected error for empty directory")
 	}
@@ -71,14 +71,14 @@ func TestAnalyzeDirectory_NotADirectory(t *testing.T) {
 	}
 	defer func() { _ = os.Remove(tmpFile.Name()) }()
 
-	_, _, err = AnalyzeDirectory(tmpFile.Name(), "us", "", "")
+	_, _, err = AnalyzeDirectory(tmpFile.Name(), "us", "", "", false)
 	if err == nil {
 		t.Error("Expected error for non-directory path")
 	}
 }
 
 func TestAnalyzeDirectory_NonExistent(t *testing.T) {
-	_, _, err := AnalyzeDirectory("/nonexistent/path/12345", "us", "", "")
+	_, _, err := AnalyzeDirectory("/nonexistent/path/12345", "us", "", "", false)
 	if err == nil {
 		t.Error("Expected error for non-existent path")
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,13 +16,14 @@ const (
 )
 
 type Config struct {
-	APKPath  string
-	DirPath  string
-	JSONFile string
-	Country  string
-	VTAPIKey string
-	KAPIKey  string
-	VTUpload bool
+	APKPath     string
+	DirPath     string
+	JSONFile    string
+	Country     string
+	VTAPIKey    string
+	KAPIKey     string
+	VTUpload    bool
+	NoPlayStore bool
 }
 
 func Load() *Config {
@@ -34,6 +35,7 @@ func Load() *Config {
 	flag.StringVar(&cfg.VTAPIKey, "vtapi", "", "VirusTotal API key")
 	flag.StringVar(&cfg.KAPIKey, "kapi", "", "Koodous API key")
 	flag.BoolVar(&cfg.VTUpload, "vtupload", false, "Upload APK to VirusTotal after analysis")
+	flag.BoolVar(&cfg.NoPlayStore, "no-play-store", false, "Skip Play Store API calls for offline analysis")
 	flag.Parse()
 
 	// Validate input options

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,21 @@ import (
 	"testing"
 )
 
+// Note: Testing flag parsing is limited because flag.Parse() is called in Load() at package init.
+// We verify the flag is registered by checking the code compiles correctly.
+// Integration tests in main package can test flag behavior with os.Args.
+
+func TestNoPlayStoreFlagExists(t *testing.T) {
+	// Verify NoPlayStore field exists in Config struct
+	cfg := &Config{}
+	// This won't compile if NoPlayStore field doesn't exist
+	_ = cfg.NoPlayStore
+	// Default should be false
+	if cfg.NoPlayStore != false {
+		t.Errorf("Expected NoPlayStore default to be false, got %v", cfg.NoPlayStore)
+	}
+}
+
 func TestGetAPIKey(t *testing.T) {
 	// Test case 1: Flag value provided
 	val := getAPIKey("flag-key", "TEST_ENV_VAR", "msg")

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -58,6 +58,10 @@ func (r *Reporter) PrintHash(hashes analyzer.Hashes) {
 
 func (r *Reporter) PrintPlayStoreInfo(app *analyzer.AndroidApp) {
 	r.printer.PrintSectionHeader("Play Store")
+	if app.NoPlayStore {
+		r.printer.PrintItalic("Analysis without Play Store")
+		return
+	}
 	if app.Errors.PlayStore != nil || app.PlayStore == nil {
 		r.printer.PrintItalic("App not found in Play Store")
 		return


### PR DESCRIPTION
## Summary
- Add `--no-play-store` flag to skip Play Store API calls
- Enables offline analysis in restricted network environments (mainland China, air-gapped networks, CI/CD pipelines)
- The flag is passed through `ProcessAPK` and `AnalyzeDirectory` functions to conditionally skip the Play Store lookup goroutine

## Changes
- `internal/config/config.go`: Add `NoPlayStore` field and `-no-play-store` flag definition
- `internal/analyzer/analyzer.go`: Add `noPlayStore` parameter to `ProcessAPK`, conditionally skip Play Store goroutine
- `internal/analyzer/batch.go`: Add `noPlayStore` parameter to `AnalyzeDirectory`
- `cmd/apkingo/main.go`: Pass `cfg.NoPlayStore` to analyzer functions
- Updated tests to include the new parameter

## Usage
```bash
# Single APK analysis
apkingo -apk app.apk -no-play-store

# Directory batch analysis
apkingo -dir /path/to/apks -no-play-store -json reports/

# Works seamlessly with JSON export
apkingo -apk app.apk -no-play-store -json report.json
```

Fixes #17